### PR TITLE
Sample fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ of the path hierarchy, those sets is skipped.
 NOTE: On windows, do NOT include the ending backslash! There is a bug with powershell
 in how it handles backslashes and how python interprets backslashes as escape characters:
 `abletoolz "D:\somefolder\"` # BAD
+
 `abletoolz "D:\somefolder"` # GOOD
+
 without quotes, backslashes are fine (but you'll need to use quotes if you have spaces in the directory path)
 `abletoolz D:\somefolder\` # GOOD
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ![Check plugins](/doc/new.png)
 # Abletoolz
 
-So what is Abletoolz? It's a Python command line tool to do operations & analysis on single files and directories of Ableton
-Live sets. Currently you can change all your Master/Cue out channels (for example make all your sets use
+So what is Abletoolz? It's a Python command line tool to change and Ableton sets. Currently you can change all your Master/Cue out channels (for example make all your sets use
 stereo out 7/8 for master),
 find out all your missing
 samples and plugins and change your set filenames to append the length of the longest clip/furthest bar and bpm. The
@@ -13,6 +12,8 @@ under the directory `abletoolz_backup` before creating the edited set file as a 
 Supports both Windows and MacOS created sets.
 
 ## Updates
+- Added `--db` to create a sample database, which can then be used with `--fix-samples-collect` and `--fix-samples-absolute` to automatically fix any broken
+sample references.
 - Ableton 8, 9, 10 and 11/11.1b sets are now supported.
 - Abletoolz now preserves your set file creation/modification times by storing them before writing changes and then
 modifying the file after.
@@ -75,8 +76,20 @@ Mac Audio Units/AU are not stored with paths, just plugin names. Mac OS is not s
 
 `--list-tracks` List track information.
 
+### Create sample database(used for automatic sample fixing)
+
+`--db folder/with/samples` Build up a database of all samples that is used when
+you run `--fix-samples-collect` or `--fix-samples-absolute`. This file gets stored in your home directory.
+
 ### Edit
 These will only edit sets in memory unless you use `-s/--save` explicitly to commit changes.
+
+`--fix-samples-collect` Go through each sample reference in the ableton set, and if any are missing try to match them based on last modification date, file size and name from the database created with `--db`. Sample is copied into the set's
+project folder, the same action as collect and save in ableton.
+
+ `--fix-samples-absolute` The same thing as `--fix-samples-collect`, just doesn't
+ copy the sample and instead puts the full path. Note, on MacOS, ableton 10/9 set
+ files seem to have issues using this, so use `--fix-samples-collect` for those.
 
 `--unfold` or `--fold` unfolds/folds all tracks in set.
 
@@ -124,6 +137,7 @@ set name. For example,
 `myset.als` --> `myset_32bars_90bpm.als`. Running this multiple times overwrites this section only (so your filename
 wont keep growing).
 
+`--prepend-version` Puts the ableton version used to create set at beginning of file name.
 
 ## Examples
 Check all samples in sets
@@ -161,15 +175,9 @@ abletoolz "D:\all_sets\myset.als" -s --append-bars-bpm
 ![Append bars bpm](/doc/append_bars_bpm.png)
 
 ## Future plans
-- Add color functions to color tracks/clips with gradients or other fun stuff.
-- Collect sample path errors when both absolute and relative paths are broken into a report file.
-- Missing sample fix feature:
-    - Add crc verify for samples, since ableton does store a crc number in the set.
-    - Currently I've added a database feature that will build up a json file to track all samples. Implementing
-    the missing sample fix is next, but getting it to work across older ableton versions will take some work since
-    mac/windows use different types of binary encoded hex.
 - Figure out way to verify AU plugins on MacOs.
+- Figure out how ableton calculates CRC's for samples and use it to make more
+accurate sample fixing.
 - Attempt to detect key based on non drum track midi notes.
-- Add support for different time signatures besides 4/4.
-- Add more track and clip specific analysing/editing functions.
-- Figure out how to create package with setup tools and put this on PyPy.
+- Add color functions to color tracks/clips with gradients or other fun stuff.
+- Put this on PyPy so it's easier to install.

--- a/abletoolz/ableton_set.py
+++ b/abletoolz/ableton_set.py
@@ -161,7 +161,9 @@ class AbletonSet(object):
                 logger.error("%s%sIs pre Ableton 8.2.x which is unsupported.", R, self.path)
                 return False
             elif first_two_bytes != b"\x1f\x8b":
-                logger.error("%s%sFile format is not gzip!, cannot open.", R, self.path)
+                logger.error(
+                    "%s%sFile is not .als or is an older format that doesn't use gzip!, cannot open...", R, self.path
+                )
                 return False
         self.get_file_times()
         with gzip.open(self.path, "r") as fd:

--- a/abletoolz/cli.py
+++ b/abletoolz/cli.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 
 from abletoolz import __version__
 from abletoolz.ableton_set import AbletonSet
-from abletoolz.misc import BACKUP_DIR, CB, B, C, ElementNotFound, R, Y
+from abletoolz.misc import BACKUP_DIR, CB, B, C, ElementNotFound, M, R, Y
 from abletoolz.sample_databaser import create_db
 
 logger = logging.getLogger(__name__)
@@ -252,7 +252,7 @@ def process(args: argparse.Namespace) -> int:
         # TODO(fix this general exception and below)
         except ElementNotFound:
             logger.info(traceback.format_exc())
-
+        logger.info("%s\n\n%s\n\n", M, "|" * 100)
     logger.info(
         "%sTook %s to process %s set(s)", CB, datetime.timedelta(seconds=time.time() - start_time), len(pathlib_objects)
     )

--- a/abletoolz/decode_encode.py
+++ b/abletoolz/decode_encode.py
@@ -1,0 +1,60 @@
+"""Encoding and decoding ableton set xml tools."""
+
+import binascii
+import textwrap
+from typing import Literal, Tuple, Union, overload
+
+
+class ParseError(Exception):
+    """Error decoding/encoding."""
+
+
+def xml_to_string(xml_str: str) -> Tuple[str, int]:
+    """Strip xml hex data from ableton xml into single string."""
+    if not xml_str:
+        raise DecodeError(f"No text to parse! {xml_str}")
+    levels = xml_str.splitlines()[1].count("\t")
+    return xml_str.replace("\t", "").replace(" ", "").replace("\n", ""), levels
+
+
+@overload
+def hex_to_string(hex_str: str, return_bytes: Literal[False] = False) -> str:
+    ...
+
+
+@overload
+def hex_to_string(hex_str: str, return_bytes: Literal[True]) -> bytes:
+    ...
+
+
+def hex_to_string(hex_str: str, return_bytes: bool = False) -> Union[str, bytes]:
+    """Input is string, but it's actually encoded bytes in hex form.
+
+    Decode hex to actual string representation.
+    Format is character, null byte, character, null byte ...
+    """
+    byte_data = bytearray.fromhex(hex_str)
+    if return_bytes:
+        return byte_data
+    return byte_data.decode("utf-16")
+
+
+def string_to_hex(in_str: str) -> str:
+    """Reverse of hex_to_string, take input string and turn into hex encoded string.
+
+    Two extra Null bytes are at the end of the string(?)
+    """
+    byte_str = in_str.encode("utf-8")
+    prepped = "".join([f"{x:x}00" for x in byte_str]).upper()
+    return prepped + "0000"
+
+
+def string_to_xml(in_str: str, levels: int = 14) -> str:
+    """Reverse of xml_to_string, add in tabs and chunk data into 80 character wide block."""
+    indent = "\t" * levels
+    width = 80 + levels
+    parsed = textwrap.wrap(
+        in_str, initial_indent=indent, subsequent_indent=indent, break_long_words=True, tabsize=4, width=width
+    )
+    ending_indent = '\t' * (levels - 1)
+    return "\n" + "\n".join(parsed) + f"\n{ending_indent}"

--- a/abletoolz/misc.py
+++ b/abletoolz/misc.py
@@ -2,16 +2,16 @@
 
 import pathlib
 import sys
-import xml.etree
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Literal, Optional, Tuple, Union, overload
 from xml.etree import ElementTree
 
 import colorama
 
 colorama.init(autoreset=True)
 
-# These are the hex values of the drop down color menu, arranged in the same order.
+# These are the hex values of the drop down color menu, arranged in the same order of rows and columns.
 # yapf: disable
+# fmt: off
 ableton_colors = [
     0xFF94A6, 0xFFA428, 0xCD9827, 0xF6F57C, 0xBEFA00, 0x21FF41, 0x25FEA9, 0x5DFFE9, 0x8AC5FE, 0x5480E4, 0x93A6FF, 0xD86CE4, 0xE552A1, 0xFFFEFE,
     0xFE3637, 0xF66D02, 0x99734A, 0xFEF134, 0x87FF67, 0x3DC201, 0x01BEAF, 0x18E9FE, 0x10A4EE, 0x007DC0, 0x886CE4, 0xB776C6, 0xFE38D4, 0xD1D0D1,
@@ -23,17 +23,18 @@ ableton_colors = [
 
 STEREO_OUTPUTS: Dict[int, Dict[str, str]] = {
     1: {"target": "AudioOut/External/S0",  "lower_display_string": "1/2"},
-    2: { "target": "AudioOut/External/S1", "lower_display_string": "3/4"},
+    2: {"target": "AudioOut/External/S1", "lower_display_string": "3/4"},
     3: {"target": "AudioOut/External/S2", "lower_display_string": "5/6"},
     4: {"target": "AudioOut/External/S3", "lower_display_string": "7/8"},
     5: {"target": "AudioOut/External/S4", "lower_display_string": "9/10"},
-    6: { "target": "AudioOut/External/S5", "lower_display_string": "11/12"},
-    7: { "target": "AudioOut/External/S6", "lower_display_string": "13/14"},
+    6: {"target": "AudioOut/External/S5", "lower_display_string": "11/12"},
+    7: {"target": "AudioOut/External/S6", "lower_display_string": "13/14"},
     8: {"target": "AudioOut/External/S7", "lower_display_string": "15/16"},
     9: {"target": "AudioOut/External/S8", "lower_display_string": "17/18"},
     10: {"target": "AudioOut/External/S9","lower_display_string": "19/20"},
 }
 # yapf: enable
+# fmt: on
 
 
 # Shorten color variables
@@ -76,12 +77,46 @@ class ElementNotFound(Exception):
     """Element doesnt exist within the xml hierarchy where expected."""
 
 
+@overload
 def get_element(
     root: ElementTree.Element,
     attribute_path: str,
-    attribute: Optional[str] = None,
+    *,
+    silent_error: Literal[False],
+    attribute: Literal[None] = None,
+) -> ElementTree.Element:
+    ...
+
+
+@overload
+def get_element(
+    root: ElementTree.Element,
+    attribute_path: str,
+    *,
+    silent_error: Literal[True],
+    attribute: Literal[None] = None,
+) -> Optional[ElementTree.Element]:
+    ...
+
+
+@overload
+def get_element(
+    root: ElementTree.Element,
+    attribute_path: str,
+    *,
+    silent_error: Literal[False] = False,
+    attribute: str,
+) -> str:
+    ...
+
+
+def get_element(
+    root: ElementTree.Element,
+    attribute_path: str,
+    *,
     silent_error: bool = False,
-) -> Union[xml.etree.ElementTree.Element, str, None]:
+    attribute: Optional[str] = None,
+) -> Union[ElementTree.Element, str, None]:
     """Get element using Element tree xpath syntax."""
     element = root.findall(f"./{'/'.join(attribute_path.split('.'))}")
     if not element:

--- a/abletoolz/sample_databaser/create_db.py
+++ b/abletoolz/sample_databaser/create_db.py
@@ -14,24 +14,25 @@ logger = logging.getLogger(__name__)
 
 def get_all_audio_files(path: pathlib.Path) -> List[pathlib.Path]:
     """Find all supported audio files in directory."""
-    aiff_files = path.rglob("*.aiff")
-    aif_files = path.rglob("*.aif")
-    wav_files = path.rglob("*.wav")
-    mp3_files = path.rglob("*.mp3")
-    flacc_files = path.rglob("*.flacc")
-    ogg_files = path.rglob("*.ogg")
-    mp4_files = path.rglob("*.mp4")
-
+    file_suffixes = [
+        "*.aiff",
+        "*.AIFF",
+        "*.aif",
+        "*.AIF",
+        "*.wav",
+        "*.WAV",
+        "*.mp3",
+        "*.MP3",
+        "*.flacc",
+        "*.FLACC",
+        "*.ogg",
+        "*.OGG",
+        "*.mp4",
+        "*.MP4",
+    ]
     all_files: List[pathlib.Path] = []
-    for file_type in (
-            aiff_files,
-            wav_files,
-            mp3_files,
-            flacc_files,
-            ogg_files,
-            mp4_files,
-    ):
-        all_files.extend(list(file_type))
+    for file_type in file_suffixes:
+        all_files.extend(list(path.rglob(file_type)))
     return all_files
 
 
@@ -41,7 +42,9 @@ def create_or_update_db(paths: List[str], db_path: Optional[pathlib.Path] = None
     db {
         path_string: {
             file_size: sample file size,
-            crc: crc size # Unsupported for now, can't figure out ableton's crc algorithm!
+            # Crc unsupported for now, can't figure out ableton's crc algorithm! This would allow for
+            # near perfect matches, although file size and perfectly matching file name is probably good enough.
+            crc: crc size
             last_modified: time of last file modification.
         }
     }
@@ -53,14 +56,14 @@ def create_or_update_db(paths: List[str], db_path: Optional[pathlib.Path] = None
         "an existing one is much faster!",
         db_path.resolve(),
     )
-    if not db_path.exists(): 
+    if not db_path.exists():
         db = {}
     else:
         with db_path.open("r") as f:
             db = json.load(f)
     all_files = []
     for path in paths:
-        all_files.extend(get_all_audio_files(pathlib.Path(path))) 
+        all_files.extend(get_all_audio_files(pathlib.Path(path)))
 
     for sample in tqdm.tqdm(all_files, desc="Progress"):
         if str(sample.resolve()) in db:
@@ -76,9 +79,9 @@ def create_or_update_db(paths: List[str], db_path: Optional[pathlib.Path] = None
     return db_path
 
 
-def load_db() -> Dict[str, Dict[str, str]]:
+def load_db() -> Dict[str, Dict[str, Dict[str, str]]]:
     """Load db from json."""
     if not DEFAULT_DB_PATH.exists():
-        raise FileNotFoundError("Database doesn't exist! Run --db with sample dir(s) first.")
+        raise FileNotFoundError(f"Database {DEFAULT_DB_PATH} doesn't exist! Run --db with sample dir(s) first.")
     with DEFAULT_DB_PATH.open() as f:
         return json.load(f)

--- a/abletoolz/utils.py
+++ b/abletoolz/utils.py
@@ -1,10 +1,15 @@
 """Random util functions."""
 import datetime
 import logging
+import os
 import pathlib
-from typing import Optional
+from typing import Optional, Tuple
+from xml.etree import ElementTree
 
-from abletoolz.misc import BACKUP_DIR, B, R, Y
+import pydantic
+
+from abletoolz import decode_encode
+from abletoolz.misc import BACKUP_DIR, B, ElementNotFound, R, Y, get_element
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +29,12 @@ def create_backup(pathlib_obj: pathlib.Path) -> None:
         if pathlib.Path(backup_path).exists():
             ending_int += 1
         else:
-            logger.info("%sMoving original file to backup directory:\n%s --> %s", B, pathlib_obj, backup_path)
+            logger.info(
+                "%sMoving original file to backup directory:\n%s --> %s",
+                B,
+                pathlib_obj,
+                backup_path,
+            )
             # Rename creates a new pathlib object with the new path,
             # so pathlib_obj will still point to the original path when the file is saved.
             pathlib_obj.rename(backup_path)
@@ -82,3 +92,279 @@ def parse_windows_data(byte_data: bytes, abs_hash_path: str) -> Optional[str]:
     except UnicodeDecodeError as e:
         logger.error("\n\n%s Couldn't decode: %s, Error: %s\n\n", R, abs_hash_path, e)
     return None
+
+
+def parse_hex_path(text: str) -> Optional[str]:
+    """Take raw hex string from XML entry and parses."""
+    if not text:
+        return None
+    # Strip new lines and tabs from raw text to have one long hex string.
+    abs_hash_path = text.replace("\t", "").replace("\n", "")
+    byte_data = bytearray.fromhex(abs_hash_path)
+    if byte_data[0:3] == b"\x00" * 3:  # Header only on mac projects.
+        # self.set_os = SetOperatingSystem.MAC_OS
+        return parse_mac_data(byte_data, abs_hash_path)
+    else:
+        # self.set_os = SetOperatingSystem.WINDOWS_OS
+        return parse_windows_data(byte_data, abs_hash_path)
+
+
+def get_sample_size(file_ref: ElementTree.Element) -> int:
+    for file_size_str in ["OriginalFileSize", "FileSize"]:
+        file_size = file_ref.findall(f".//{file_size_str}")
+        # if file_size is None:
+        #     raise ElementNotFound("Couldn't get sample size!")
+        if len(file_size):
+            try:
+                return int(file_size[0].get("Value", ""))
+            except ValueError as exc:
+                raise ElementNotFound from exc
+    logger.error("Couldn't find filesize!")
+    return 0
+
+
+def path_separator_type(path_str: str) -> str:
+    """Get OS path string separator."""
+    if "\\" in path_str:
+        return "\\"
+    elif "/" in path_str:
+        return "/"
+    else:
+        raise Exception(f"Couldn't parse OS path type! {path_str}")
+
+
+def check_relative_path(
+    name: str,
+    sample_element: ElementTree.Element,
+    project_root_folder: pathlib.Path,
+) -> Tuple[Optional[pathlib.Path], Optional[pathlib.Path]]:
+    """Constructs absolute path from project root and relative path stored in set."""
+    if not project_root_folder:
+        return None, None
+    relative_path_enabled = get_element(sample_element, "FileRef.HasRelativePath", attribute="Value")
+    relative_path_type = get_element(sample_element, "FileRef.RelativePathType", attribute="Value")
+    if relative_path_enabled == "true" and relative_path_type == "3":
+        relative_path_element = get_element(sample_element, "FileRef.RelativePath")
+        sub_directory_path = []
+        for path in relative_path_element:
+            sub_directory_path.append(path.get("Dir"))
+        from_project_root = f"{os.path.sep.join(sub_directory_path)}{os.path.sep}{name}"
+        full_path = project_root_folder / os.path.sep.join(sub_directory_path) / name
+        return full_path, from_project_root
+    return None, None
+
+
+class SampleRef(pydantic.BaseModel):
+    """Sample ref model.
+
+    Parse and recreate XML elements in these formats:
+
+    11+ Example:
+        <RelativePathType Value="3" />
+        <RelativePath Value="Samples/Imported/2051 BASS.wav" />
+        <Path Value="D:/AbletonSync/Drum N Bass/Samples/Imported/2051 BASS.wav" />
+        <Type Value="1" />
+        <LivePackName Value="" />
+        <LivePackId Value="" />
+        <OriginalFileSize Value="58394528" />
+        <OriginalCrc Value="7866" />
+
+    9 - 10 Example:
+        <HasRelativePath Value="true" />
+        <RelativePathType Value="3" />
+        <RelativePath>
+            <RelativePathElement Id="0" Dir="Samples" />
+            <RelativePathElement Id="1" Dir="Processed" />
+            <RelativePathElement Id="2" Dir="Freeze" />
+        </RelativePath>
+        <Name Value="Freeze 2-Drum Rack.wav" />
+        <Type Value="1" />
+        <Data>
+            46003A005C004500780070006F00720074005C00410062006C00650074006F006E00200050007200
+            6F006A0065006300740073005C0063006800610072006700650064002000500072006F006A006500
+            630074005C00530061006D0070006C00650073005C00500072006F00630065007300730065006400
+            5C0046007200650065007A0065005C0046007200650065007A006500200032002D00440072007500
+            6D0020005200610063006B002E007700610076000000
+        </Data>
+        <RefersToFolder Value="false" />
+        <SearchHint>
+            <PathHint>
+                <RelativePathElement Id="0" Dir="Ableton Projects" />
+                <RelativePathElement Id="1" Dir="charged Project" />
+                <RelativePathElement Id="2" Dir="Samples" />
+                <RelativePathElement Id="3" Dir="Processed" />
+                <RelativePathElement Id="4" Dir="Freeze" />
+            </PathHint>
+            <FileSize Value="0" />
+            <Crc Value="0" />
+            <MaxCrcSize Value="0" />
+            <HasExtendedInfo Value="false" />
+        </SearchHint>
+    """
+
+    name: str
+    size: int
+    last_modified: int
+    crc: int
+    relative_type_element: ElementTree.Element
+    sample_ref: ElementTree.Element
+    absolute_element: ElementTree.Element
+    relative_element: ElementTree.Element
+    version_tuple: Tuple[int, int, int]
+
+    absolute: Optional[pathlib.Path] = None
+    relative: Optional[pathlib.Path] = None
+    project_root: Optional[pathlib.Path] = None
+
+    class Config:
+        """Pydantic config."""
+
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def from_element(
+        cls,
+        sample_ref: ElementTree.Element,
+        version_tuple: Tuple[int, int, int],
+        project_root_folder: pathlib.Path,
+    ) -> "SampleRef":
+        """Parse ElementTree into class.
+
+        11 > switched to simple string paths, before 11 used binary encoded data, which
+        differs for Windows and MacOs.
+        """
+        last_modified = sample_ref.find("LastModDate").get("Value")
+        file_ref = sample_ref.find("FileRef")
+        file_size = get_sample_size(file_ref)
+        relative_type_element = file_ref.find("RelativePathType")
+        if version_tuple >= (11, 0, 0):
+            absolute_element = file_ref.find("Path")
+            crc = file_ref.find("OriginalCrc").get("Value")
+            absolute = file_ref.find("Path").get("Value")
+            relative_element = file_ref.find("RelativePath")
+            relative = file_ref.find("RelativePath").get("Value")
+            name = pathlib.Path(absolute).name
+        else:
+            absolute_element = file_ref.find("Data")
+            absolute = parse_hex_path(absolute_element.text)
+            name = file_ref.find("Name").get("Value", "")
+            try:
+                crc = file_ref.findall(".//Crc")[0].get("Value")
+            except IndexError:
+                crc = 0
+                ElementTree.dump(file_ref)
+            relative, _ = check_relative_path(name, sample_ref, project_root_folder)
+            relative_element = file_ref.find("RelativePath")
+
+        return cls(
+            name=name,
+            size=file_size,
+            last_modified=last_modified,
+            relative_type_element=relative_type_element,
+            relative_element=relative_element,
+            sample_ref=sample_ref,
+            crc=crc,
+            absolute_element=absolute_element,
+            absolute=pathlib.Path(absolute) if absolute else None,
+            relative=pathlib.Path(relative) if relative else None,
+            project_root=project_root_folder,
+            version_tuple=version_tuple,
+        )
+
+    @property
+    def absolute_exists(self) -> bool:
+        return self.absolute and self.absolute.exists()
+
+    @property
+    def relative_exists(self) -> bool:
+        return self.relative and (self.project_root / self.relative).exists()
+
+    def get_original_file_ref(self) -> ElementTree.Element:
+        return get_element(self.sample_ref, "SourceContext.SourceContext.OriginalFileRef.FileRef")
+
+    def set_absolute(self, path: pathlib.Path) -> None:
+        """Set absolute path for sample ref xml element."""
+        if self.version_tuple < (11, 0, 0):
+            # Get indentation level from current xml data.
+            _, levels = decode_encode.xml_to_string(self.absolute_element.text)
+            # Set new value.
+            hex_string = decode_encode.string_to_hex(str(path))
+            formatted_xml = decode_encode.string_to_xml(hex_string, levels=levels)
+            self.absolute_element.text = formatted_xml
+            try:
+                second_ref = get_element(self.sample_ref, "SourceContext.SourceContext.OriginalFileRef.FileRef.Data")
+            except ElementNotFound:
+                return
+            _, levels = decode_encode.xml_to_string(second_ref.text)
+            formatted_xml = decode_encode.string_to_xml(hex_string, levels=levels)
+            second_ref.text = formatted_xml
+
+            return
+
+        self.absolute_element.set("Value", str(path))
+
+    def set_relative(self, path: str) -> None:
+        """Set relative path from project root.
+
+        Pre 11
+            <HasRelativePath Value="true" />
+            <RelativePath>
+                <RelativePathElement Dir="Samples" />
+                <RelativePathElement Dir="Imported" />
+            </RelativePath>
+
+        Post 11
+            <RelativePathType Value="3" />
+            <RelativePath Value="Samples/Imported/2051 BASS.wav" />
+        """
+        if self.version_tuple < (11, 0, 0):
+            # Clear out old entries
+            old = [e for e in self.relative_element]
+            tails = [x.tail for x in old]
+            for e in old:
+                self.relative_element.remove(e)
+            for i, folder in enumerate(path.split("/")[:-1]):
+                element = ElementTree.Element("RelativePathElement", attrib=dict(Dir=folder))
+                element.tail = tails[i]
+                self.relative_element.append(element)
+            return
+        self.relative_element.set("Value", path)
+
+    def get_relative_value(self) -> pathlib.Path:
+        """Get path from relative xml element."""
+        if self.version_tuple < (11, 0, 0):
+            sub_directory_path = []
+            for path in self.relative_element:
+                sub_directory_path.append(path.get("Dir"))
+            return pathlib.Path("/".join(sub_directory_path))
+        return pathlib.Path(self.relative_element.get("Value")).parent
+
+    def set_relative_type(self, type_int: int) -> None:
+        """Set relative path type.
+
+        <RelativePathType Value="3" />
+        1 or 0 is absolute (?)
+        3 is relative from project root
+        """
+        if self.version_tuple < (11, 0, 0):
+            try:
+                has_rel_ele = get_element(self.sample_ref, "FileRef.HasRelativePath")
+                if type_int == 3:
+                    has_rel_ele.set("Value", "true")
+                elif type_int in {0, 1}:
+                    has_rel_ele.set("Value", "false")
+            except ElementNotFound:
+                pass
+        self.relative_type_element.set("Value", str(type_int))
+
+    def get_relative_type(self) -> int:
+        """Get relative path type (integer)."""
+        return int(self.relative_type_element.get("Value"))
+
+    def clear_search_hints(self) -> None:
+        """Remove search hints, which are the sample paths to folders in abletons browser."""
+        # search_hints = self.sample_ref.findall("SearchHint")
+        for search_hint in self.sample_ref.iter("SearchHint"):
+            refs = [e for e in search_hint]
+            for ref in refs:
+                search_hint.remove(ref)


### PR DESCRIPTION
Add tools to build up a sample database using --db on any folder with audio files, and two commands --fix-samples-collect and --fix-samples-absolute to either copy the samples into the set project folder(collect and save) or just point the broken reference to the found sample without copying. 